### PR TITLE
Убрал динамический параметр деплоя env.CSSSR_SPACE_ORIGIN

### DIFF
--- a/.github/kuberta.yaml
+++ b/.github/kuberta.yaml
@@ -7,11 +7,6 @@ releases:
     chart: csssr/csssr-com@~1.0.0
     static-params:
       environment: testing
-    params:
-      env.CSSSR_SPACE_ORIGIN:
-        type: url
-        description: Адрес csssr.space
-        default: http://master.space.csssr.cloud/
     builds:
       - workflow: build-docker-image.yml
         values:


### PR DESCRIPTION
Андрей попросил сделать, чтобы стенды смотрели на csssr.space. Сделал `https://csssr.space` дефолтным значением переменной окружения https://github.com/CSSSR/csssr.com-chart/commit/b0e241a5f69594c306985c29de476ef92958b23b, а здесь вообще убрал параметр