### PR TITLE
COM-2666: E2E тесты_500я

### DIFF
--- a/e2e-tests/nightwatch/screenshots/base/07_500/500я_(RU)/chrome-1200x1200.png
+++ b/e2e-tests/nightwatch/screenshots/base/07_500/500я_(RU)/chrome-1200x1200.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:346414471ae3a5afe0b246a201a8be57cccb64d2d9019112ace61e4353072362
+size 173520

--- a/e2e-tests/nightwatch/tests/07 500.test.js
+++ b/e2e-tests/nightwatch/tests/07 500.test.js
@@ -1,0 +1,32 @@
+testcase('Отображение стилизованной страницы 500 ошибки (RU)', () => {
+	step('Переходим на страницу с 500й', () => {
+		browser
+			.url(browser.launch_url + '/_error')
+			.setWindowSize(1200, 1200)
+	})
+
+	expected('Отобразилась стилизованная страница 500', () => {
+		browser
+			.waitForElementPresent('#__next > main > div > svg > g')
+			.assert.screenshotElement(
+				'#__next',
+				'500я (RU)'
+			)
+	})
+})
+
+testcase('Кликабельный email на странице 500 ошибки (RU)', () => {
+	step('Переходим на страницу с 500й', () => {
+		browser
+			.url(browser.launch_url + '/_error')
+			.setWindowSize(1200, 1200)
+	})
+
+	expected('Для launch@csssr.com верная ссылка для открытия почтового клиента', () => {
+		browser.getAttribute('#__next > main > h2 > a', 'href', function (result) {
+			if (result.value !== 'mailto:launch@csssr.com') {
+				throw new Error(`Некорректная ссылка для email в футере( ${result.value} )`)
+			}
+		})
+	})
+})


### PR DESCRIPTION
- Отображение стилизованной страницы 500 ошибки
- Кликабельный email на странице 500 ошибки

## Задача
- ссылка на jira: https://jira.csssr.io/browse/COM-2666
- стенд: https://csssr.com/_error

### Релиз
* https://jira.csssr.io/projects/COM/versions/__HERE_JIRA_VERSION_ID__
* стенд: http://release-__HERE_JIRA_RELEASE_ID__.csssr.cloud

## Чек-лист
- [ ] PR в ветку релиза
- [ ] Указаны ревьюеры
- [ ] Стенды собрались и работают
- [ ] Код работает полностью согласно описанию задачи
- [ ] eslint и dev-консоль браузера без ошибок

## Дополнительно
* документация по добавленным библиотекам
* скриншоты
