### PR TITLE
COM-2794: Update sitemap to latest version and update its usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react-reveal": "^1.2.2",
     "react-transition-group": "^4.4.1",
     "scroll-lock": "^2.1.4",
-    "sitemap": "6.3.2"
+    "sitemap": "^6.3.2"
   },
   "devDependencies": {
     "@csssr/eslint-config-core": "^1.1.0",

--- a/server/generate-sitemap.js
+++ b/server/generate-sitemap.js
@@ -1,6 +1,7 @@
 import { supportedLocales } from '../common/locales-settings'
 
-const sitemap = require('sitemap')
+const { SitemapStream, streamToPromise } = require('sitemap')
+const { Readable } = require('stream')
 const csssrSpaceOrigin = require('../utils/csssrSpaceOrigin')
 
 const thirtyMinutes = 30 * 60 * 1000
@@ -669,11 +670,13 @@ const sitemapUrlsSettings = [
 ].concat(getJobsSitemapUrlsSettings())
 
 const generateSitemap = () =>
-  getVacancies().then((vacanciesUrls) =>
-    sitemap.createSitemap({
-      urls: [...sitemapUrlsSettings, ...vacanciesUrls],
-    }),
-  )
+  getVacancies().then((vacanciesUrls) => {
+    const links = [...sitemapUrlsSettings, ...vacanciesUrls]
+
+    const stream = new SitemapStream({ hostname: 'https://blog.csssr.com/' })
+
+    return streamToPromise(Readable.from(links).pipe(stream)).then((data) => data.toString())
+  })
 
 const sitemapUrls = sitemapUrlsSettings.map((sitemapUrlSettings) => sitemapUrlSettings.url)
 

--- a/server/index.js
+++ b/server/index.js
@@ -146,9 +146,8 @@ const startApp = async () => {
 
   server.get('/sitemap.xml', (req, res) => {
     generateSitemap().then((sitemap) => {
-      const xml = sitemap.toXML()
       res.header('Content-Type', 'application/xml')
-      res.send(xml)
+      res.send(sitemap)
     })
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8691,7 +8691,7 @@ sisteransi@^1.0.4:
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.4.tgz#386713f1ef688c7c0304dc4c0632898941cad2e3"
   integrity sha512-/ekMoM4NJ59ivGSfKapeG+FWtrmWvA1p6FBZwXrqojw90vJu8lBmrTxCMuBCydKtkaUe2zt4PlxeTKpjwMbyig==
 
-sitemap@6.3.2:
+sitemap@^6.3.2:
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/sitemap/-/sitemap-6.3.2.tgz#a72b9b3a522acf889c1c5965364e5d66f2ef32cf"
   integrity sha512-JmOG+bYzUfqXFfvh4JZocRvjrPGJddCWuDqiCTDe8me28CGCkWHYRtTFyTnmZu4x0SoD/6KNDGd88Fc5wBYlfQ==


### PR DESCRIPTION
## Задача
- ссылка на jira: COM-2794
- стенд: http://com-2794.com.csssr.cloud

В мастер попало обновление sitemap с новым API использования, из-за этого была проблема.